### PR TITLE
Chore: Adicionando .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/vendor
+composer.lock
+.env


### PR DESCRIPTION
Adicionando .gitignore para que arquivos indesejados não atrapalhem o versionamento do projeto e para que os de configuração de ambiente não sejam expostos.